### PR TITLE
Add Pharos API

### DIFF
--- a/api-docs-urls.csv
+++ b/api-docs-urls.csv
@@ -561,3 +561,4 @@ Microsoft Graph To-Do API,https://learn.microsoft.com/en-us/graph/api/resources/
 Twilio Email API,https://www.twilio.com/docs/sendgrid,https://www.twilio.com/legal/privacy,https://www.twilio.com/legal/tos,https://www.twilio.com/changelog
 Microsoft Graph Calendar Events API,https://learn.microsoft.com/en-us/graph/api/resources/event,https://privacy.microsoft.com/en-us/privacystatement,https://learn.microsoft.com/en-us/graph/throttling,https://learn.microsoft.com/en-us/security,https://techcommunity.microsoft.com/t5/calendar-events/ct-p/CalendarEvents
 Zendesk SLA Policies API,https://www.zendesk.com/company/customers-partners/privacy-policy/,https://www.zendesk.com/company/terms,https://support.zendesk.com/hc/en-us/community/topics
+Pharos Watch API,https://pharos.watch/about/api/,https://pharos.watch/about/,https://pharos.watch/about/,,,,


### PR DESCRIPTION
Adds [Pharos Watch API](https://pharos.watch/about/api/) to the dataset.

Pharos is a public stablecoin analytics dashboard tracking 390+ stablecoins with a free, open REST API providing price, market cap, peg deviation, supply, and chain health data.